### PR TITLE
Clear Interval to xit program if doesJustPrintHelpInfo is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -480,7 +480,7 @@ function detectInternetConnectivity() {
 timer = setInterval(detectInternetConnectivity, 2000);
 
 if (!doseJustPrintHelpInfo) {
-  // Initailize progress bar
+  // Initialize progress bar
   console.log('');
   progressBar.start(fileStats.currentTotal, fileStats.downloaded, {
     status: 'downloading...',
@@ -488,4 +488,6 @@ if (!doseJustPrintHelpInfo) {
   });
 
   initializeDownload(parameters);
+} else {
+  clearInterval(timer);
 }


### PR DESCRIPTION
Currently the program will hang even if users just want to print help or input the wrong url, making them use Ctrl+C to exit.

In the code, there is actually the logic for a variable `doesJustPrintHelpInfo`, but somehow the owner forgot to clear the `timer` interval, which is the interval to check for Internet connection every few seconds.

I add the code to clear the `timer` interval when `doesJustPrintHelpInfo` is true to allow the program to exit.